### PR TITLE
Fixed Telnet on Cowrie, LoadBalancer can take IP ranges and seperate IPs

### DIFF
--- a/frontend/assets/js/custom_build.js
+++ b/frontend/assets/js/custom_build.js
@@ -327,7 +327,7 @@ function addDionaea() {
       // When LoadBalancer is selected
       var ipForm = document.getElementById("dio-ip-field").value;
       // Validate IP address
-      if (!validateIp(ipForm, "dio-err-div", "dio-error-msg")) {
+      if (!validateManyIpRanges(ipForm, "dio-err-div", "dio-error-msg")) {
         return;
       }
       node = 0;
@@ -513,7 +513,7 @@ function addConpot() {
       // When LoadBalancer is selected
       var ipForm = document.getElementById("conpot-ip-field").value;
       // Validate IP address
-      if (!validateIp(ipForm, "conpot-err-div", "conpot-error-msg")) {
+      if (!validateManyIpRanges(ipForm, "conpot-err-div", "conpot-error-msg")) {
         return;
       }
       node = 0;
@@ -617,7 +617,7 @@ function addCowrie() {
       // When LoadBalancer is selected
       var ipForm = document.getElementById("cowrie-ip-field").value;
       // Validate IP address
-      if (!validateIp(ipForm, "cowrie-err-div", "cowrie-error-msg")) {
+      if (!validateManyIpRanges(ipForm, "cowrie-err-div", "cowrie-error-msg")) {
         return;
       }
       node = 0;

--- a/frontend/assets/js/validations.js
+++ b/frontend/assets/js/validations.js
@@ -31,6 +31,28 @@ function validateReplicas(num, div, mes) {
   }
 }
 
+// Check for valid IP address ranges
+function validateManyIpRanges(num, div, mes){
+  const num_ranges = num.split(',')
+  for (let j=0; j < num_ranges.length; j++){
+    if(!validateIpRange(num_ranges[j].trim(), div, mes)){
+      return false;
+    }
+  }
+  return true
+}
+
+// Check for valid IP address range
+function validateIpRange(num, div, mes) {
+  const num_range = num.split('-');
+  for (let i=0; i < num_range.length; i++){
+    if(!validateIp(num_range[i].trim(), div, mes)){
+      return false;
+    }
+  }
+  return true;
+}
+
 // Check for valid IP address
 function validateIp(num, div, mes) {
   var err = document.getElementById(mes);

--- a/src/create_charts.js
+++ b/src/create_charts.js
@@ -229,7 +229,7 @@ function init_deployments() {
          "    value3": "{{ $val.value | quote }}",
          "  {{- end }}": "aa"
       },
-      "  {{- end }}": "aa"
+      "  {{- end3 }}": "aa"
       
     },
   };
@@ -251,7 +251,7 @@ function init_deployments() {
          "    value2": "{{ $val.value | quote }}",
          "  {{- end }}": "aa"
       },
-      "  {{- end }}": "aa"
+      "  {{- end2 }}": "aa"
     },
   };
 }
@@ -490,7 +490,7 @@ function create_same_names(yamlStr) {
       yamlStr = yamlStr.split("resources" + i).join("resources");
       yamlStr = yamlStr.split("env" + i).join("env"); // for environment variables
       yamlStr = yamlStr.split("value" + i).join("value"); // for environment variables
-
+      yamlStr = yamlStr.split("end" + i).join("end"); // for environment variables
       yamlStr = yamlStr.split("hostPath" + i).join("hostPath");
     }
   }


### PR DESCRIPTION
Added the environment variable that cowrie needed to enable telnet. LoadBalancer can take IP ranges (192.168.1.1-192.168.1.10) and seperate IPs (192.168.1.1,192.168.1.4). Also, charts retrieve the honeypots from parasecurity repo.